### PR TITLE
build(webserver): bump v1.24.10 for expired deb.sury.org key

### DIFF
--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -167,9 +167,9 @@ jobs:
           # Create and push multi-arch manifests
           for ORG_IMAGE in ${MULTI_ARCH_IMAGES}; do
             docker buildx imagetools create -t ${ORG_IMAGE}:${TAG} ${ORG_IMAGE}:${TAG}-amd64 ${ORG_IMAGE}:${TAG}-arm64
-            if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              docker buildx imagetools create -t ${ORG_IMAGE}:latest ${ORG_IMAGE}:${TAG}
-            fi
+            # if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            #   docker buildx imagetools create -t ${ORG_IMAGE}:latest ${ORG_IMAGE}:${TAG}
+            # fi
           done
 
           # Clean up intermediary single-arch tags from remote registry

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -42,26 +42,7 @@ php84:
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
 
-# TODO: php8.5: These are the standard packages carried forward from php8.4 to php8.5
-# https://codeberg.org/oerdnj/deb.sury.org/issues/13#issuecomment-7573144
-# However, opcache is now enabled by default, so we need to add it to the list of extensions.
-# https://wiki.php.net/rfc/make_opcache_required
-# These extensions that DDEV uses are currently missing in php8.5 on Debian bookworm (arm64)
-#apcu
-#imagick
-#memcached
-#redis
-#uploadprogress
-#xdebug
-#xhprof
-#xmlrpc
-#yaml
-
-php85-todo:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
-
-# TODO: php8.5 temp workaround until php8.5 packages are available
+# php8.5: memcached not yet available in Debian Bookworm Sury arm64
 php85:
-  amd64: ["bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
-  arm64: ["bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "yaml", "zip"]


### PR DESCRIPTION
## The Issue

Using DDEV v1.24.10:

- https://github.com/ddev/ddev-gitlab-ci/issues/29

If you have custom `.ddev/web-build/Dockerfile.*`:

```
#18 2.535 W: GPG error: https://packages.sury.org/php bookworm InRelease: The following signatures were invalid: EXPKEYSIG B188E2B695BD4743 DEB.SURY.ORG Automatic Signing Key <deb@sury.org>
#18 2.535 E: The repository 'https://packages.sury.org/php bookworm InRelease' is not signed.
```

## How This PR Solves The Issue

Testing how Docker image bump works in https://hub.docker.com/u/ddevhq

https://github.com/ddev-test/ddev/actions/runs/21684159903
https://github.com/ddev-test/ddev/actions/runs/21684344439

## Manual Testing Instructions

```bash
docker run -it --rm ddev/ddev-webserver:v1.24.10 bash
```

```bash
# using DDEV v1.24.10
ddev config --web-image=ddevhq/ddev-webserver:v1.24.10
ddev start
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
