### PR TITLE
ci(macos): untap pre-installed aws/tap before brew install

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -163,6 +163,9 @@ jobs:
 
       - name: "setup macOS"
         run: |
+          # The macos-latest runner image pre-taps aws/tap, which Homebrew 6.0+
+          # flags as untrusted on every invocation. We don't use it, so remove it.
+          brew untap aws/tap || true
           brew install coreutils gnu-getopt jq
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## The Issue

- Testing PR to verify the `aws/tap` Homebrew trust warning is resolved

We saw the following annotation on the `notarize-macos` job in a main-build run:

```
The following taps are not trusted:
  aws/tap
```

This comes from Homebrew 6.0+'s new tap-trust check flagging the `aws/tap` tap that's pre-installed on GitHub's `macos-latest` runner image. We don't use that tap.

## How This PR Solves The Issue

Untaps `aws/tap` in the "setup macOS" step of `notarize-macos` before installing our own deps (`coreutils`, `gnu-getopt`, `jq`), so Homebrew's tap-trust check has nothing untrusted to complain about.

## Manual Testing Instructions

1. Push to main (or trigger `Main branch build/release (signed)` workflow via `workflow_dispatch`).
2. Confirm the `notarize-macos` job succeeds with no "taps are not trusted" annotation.

## Automated Testing Overview

No unit/integration tests apply; this is a CI workflow change verified by observing the workflow run itself.

## Release/Deployment Notes

No user-facing impact; CI-only change.
