### PR TITLE
test: verify fork-PR-comment fix for #8609 phase 2 manual test 10

### DIFF
--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -27,6 +27,7 @@ getent passwd "$(id -u)" >/dev/null 2>&1 || PS1='${debian_chroot:+($debian_chroo
 BASHRC
 EOF
 
+# test: trivial fork PR change for #8609 phase 2 manual test 10 (comment-fix verification)
 HEALTHCHECK --interval=1s --retries=5 --timeout=120s CMD ["/healthcheck.sh"]
 
 VOLUME ${SOCKET_DIR}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -55,10 +55,10 @@ var TraefikRouterTagBranch = "20260814_rfay_docker_update_phase_2"
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "bb5e9f0003" // 20260814_rfay_docker_update_phase_2-bb5e9f0003
+var SSHAuthTag = "5271601db6" // 20260816_rfay_test10_fork_comment_fix-5271601db6
 
 // SSHAuthTagBranch is the branch SSHAuthTag's content was built from.
-var SSHAuthTagBranch = "20260814_rfay_docker_update_phase_2"
+var SSHAuthTagBranch = "20260816_rfay_test10_fork_comment_fix"
 
 // XhguiImage is image for xhgui
 var XhguiImage = "ddev/ddev-xhgui"


### PR DESCRIPTION
## Short Summary (TL;DR)

Verification test for the fork-PR-comment fix (67767f1ed) for PR #8707: confirm `image-push.yml` now comments on a fork PR after approval, where it previously silently skipped commenting.

## The Issue

- Regression test for a bug found while manually testing ddev/ddev#8609 phase 2 (ddev/ddev#8707)

## How This PR Solves The Issue

Adds a comment line to `containers/ddev-ssh-agent/Dockerfile` from a fork, to exercise the full detect -> build -> approve -> push -> comment flow with the fix in place.

## Manual Testing Instructions

Watch this PR's checks on `ddev-test/ddev`:

- `build` should have no secret-loading step.
- `image-push` should request approval exactly once.
- After approval, the push should succeed and a comment listing the pushed image should appear on this PR.

## Automated Testing Overview

None; this is a manual CI exercise, not a code change requiring new tests.

## Release/Deployment Notes

None; this branch is for testing on `ddev-test/ddev` only and will not be merged.
