### PR TITLE
test: verify DOCKER_ORG fetches real value for #8609 phase 2 manual test 13

### DIFF
--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -27,6 +27,7 @@ getent passwd "$(id -u)" >/dev/null 2>&1 || PS1='${debian_chroot:+($debian_chroo
 BASHRC
 EOF
 
+# test: trivial fork PR change for #8609 phase 2 manual test 13 (real DOCKER_ORG value verification)
 HEALTHCHECK --interval=1s --retries=5 --timeout=120s CMD ["/healthcheck.sh"]
 
 VOLUME ${SOCKET_DIR}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -55,10 +55,10 @@ var TraefikRouterTagBranch = "20260814_rfay_docker_update_phase_2"
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "bb5e9f0003" // 20260814_rfay_docker_update_phase_2-bb5e9f0003
+var SSHAuthTag = "c98b5f7c0e" // 20260817_rfay_test13_dockerorg_realvalue-c98b5f7c0e
 
 // SSHAuthTagBranch is the branch SSHAuthTag's content was built from.
-var SSHAuthTagBranch = "20260814_rfay_docker_update_phase_2"
+var SSHAuthTagBranch = "20260817_rfay_test13_dockerorg_realvalue"
 
 // XhguiImage is image for xhgui
 var XhguiImage = "ddev/ddev-xhgui"


### PR DESCRIPTION
## Short Summary (TL;DR)

Verification test for the DOCKER_ORG public-variables fix now that `ddev/ddev`'s `public-variables` branch has been populated: confirm the load step actually fetches the real `ddev` value on a fork PR, instead of gracefully no-op'ing on a missing file.

## The Issue

- Regression test for a fix found while manually testing ddev/ddev#8609 phase 2 (ddev/ddev#8707)

## How This PR Solves The Issue

Adds a comment line to `containers/ddev-ssh-agent/Dockerfile` from a fork, so `detect`/`build` run with `vars.DOCKER_ORG` unavailable (the fork restriction), now that `ddev/ddev`'s `public-variables` branch has `DOCKER_ORG=ddev`.

## Manual Testing Instructions

Watch this PR's `detect` job log on `ddev-test/ddev`:

- The "Load DOCKER_ORG from public-variables branch" step should run and succeed, fetching `ddev` (not empty).
- `detect` should resolve `ddev/ddev-ssh-agent`, matching the fetched value.

## Automated Testing Overview

None; this is a manual CI exercise, not a code change requiring new tests.

## Release/Deployment Notes

None; this branch is for testing on `ddev-test/ddev` only and will not be merged.
